### PR TITLE
PoC: 動的に Auto Mouse Layer のタイムアウトを調整する

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/config.h
@@ -39,3 +39,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define POINTING_DEVICE_AUTO_MOUSE_ENABLE
 #define AUTO_MOUSE_DEFAULT_LAYER 1
+#define AUTO_MOUSE_LAYER_KEEP_TIME 30000

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/keymap.c
@@ -56,6 +56,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 layer_state_t layer_state_set_user(layer_state_t state) {
     // Auto enable scroll mode when the highest layer is 3
     keyball_set_scroll_mode(get_highest_layer(state) == 3);
+#ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
+    keyball_keep_auto_mouse_layer_if_needed(state);
+#endif
     return state;
 }
 

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/keymap.c
@@ -57,7 +57,7 @@ layer_state_t layer_state_set_user(layer_state_t state) {
     // Auto enable scroll mode when the highest layer is 3
     keyball_set_scroll_mode(get_highest_layer(state) == 3);
 #ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
-    keyball_keep_auto_mouse_layer_if_needed(state);
+    keyball_handle_auto_mouse_layer_change(state);
 #endif
     return state;
 }

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
@@ -177,6 +177,9 @@ typedef struct {
     keypos_t       last_pos;
     report_mouse_t last_mouse;
 
+    uint16_t auto_mouse_layer_timeout;
+    layer_state_t last_layer_state;
+
     // Buffer to indicate pressing keys.
     char pressing_keys[KEYBALL_OLED_MAX_PRESSING_KEYCODES + 1];
 } keyball_t;
@@ -270,3 +273,7 @@ uint8_t keyball_get_cpi(void);
 /// In addition, if you do not upload SROM, the maximum value will be limited
 /// to 34 (3500CPI).
 void keyball_set_cpi(uint8_t cpi);
+
+#ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
+void keyball_keep_auto_mouse_layer_if_needed(layer_state_t state);
+#endif

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
@@ -179,6 +179,7 @@ typedef struct {
 
     uint16_t auto_mouse_layer_timeout;
     layer_state_t last_layer_state;
+    uint16_t total_mouse_movement;
 
     // Buffer to indicate pressing keys.
     char pressing_keys[KEYBALL_OLED_MAX_PRESSING_KEYCODES + 1];
@@ -275,5 +276,5 @@ uint8_t keyball_get_cpi(void);
 void keyball_set_cpi(uint8_t cpi);
 
 #ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
-void keyball_keep_auto_mouse_layer_if_needed(layer_state_t state);
+void keyball_handle_auto_mouse_layer_change(layer_state_t state);
 #endif


### PR DESCRIPTION
Auto Mouse Layer を使うと以下のような誤爆が起こりがち。
- クリックする前にマウスレイヤーから脱してしまい、クリックのつもりが文字入力になってしまう
- 文字入力したつもりがマウスレイヤーに居たままになっていてクリックになってしまう

次の仕様によってこれらの誤爆を防止しようという試み。
- マウスレイヤーに入ったら、マウスキーを押すまでマウスレイヤーに留まり続けるようにする。

マウスカーソルを動かす目的はほとんどの場合、何かをクリックするためなので、クリックするまでマウスレイヤーを離脱する必要はない。

```mermaid
stateDiagram-v2

state "Stay on Mouse Layer" as keep
state "Mouse Layer with Short Timeout" as short
state "Default Layer" as df

df --> keep: Mouse moved
keep --> short: Mouse key clicked
short --> keep: Mouse moved
short --> df: Timeout
```

詳細な仕様は以下の通り。
- デフォルトの Auto Mouse Layer のタイムアウトを長めの 30s (`AUTO_MOUSE_LAYER_KEEP_TIME`) にする
    - クリックする前にマウスレイヤーから脱してキー入力を誤爆してしまうのを防止
- マウスキーをクリックすると 100ms ～ 1000ms の時間でマウスレイヤーを離脱
    - 通常の Auto Mouse Layer のタイムアウトと同じ方法で調整できるようにする
- マウスキークリック後にトラックボールを動かすと、タイムアウト値を `AUTO_MOUSE_LAYER_KEEP_TIME` にリセットする

意図せずマウスを動かしてしまう場合に備えて、以下の使用を追加する。
- `AML_ACTIVATE_THRESHOLD` の移動量を超えたときだけ Mouse Layer に入る

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **新機能**
	- 自動マウスレイヤーのカスタマイズ可能な持続時間を導入し、ユーザーのコントロールを向上。
	- ユーザーの操作に応じた自動マウス機能の管理を強化し、より反応の良い動作を実現。

- **バグ修正**
	- 異なるレイヤー間でのマウス機能の一貫性を改善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->