### PR TITLE
マウスキーを押すまで Auto Mouse Layer に留まり誤爆を減らす

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/config.h
@@ -39,3 +39,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define POINTING_DEVICE_AUTO_MOUSE_ENABLE
 #define AUTO_MOUSE_DEFAULT_LAYER 1
+#define AUTO_MOUSE_LAYER_KEEP_TIME 30000

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/keymap.c
@@ -56,6 +56,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 layer_state_t layer_state_set_user(layer_state_t state) {
     // Auto enable scroll mode when the highest layer is 3
     keyball_set_scroll_mode(get_highest_layer(state) == 3);
+#ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
+    keyball_keep_auto_mouse_layer_if_needed(state);
+#endif
     return state;
 }
 

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/keymap.c
@@ -57,7 +57,7 @@ layer_state_t layer_state_set_user(layer_state_t state) {
     // Auto enable scroll mode when the highest layer is 3
     keyball_set_scroll_mode(get_highest_layer(state) == 3);
 #ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
-    keyball_keep_auto_mouse_layer_if_needed(state);
+    keyball_handle_auto_mouse_layer_change(state);
 #endif
     return state;
 }

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
@@ -177,6 +177,9 @@ typedef struct {
     keypos_t       last_pos;
     report_mouse_t last_mouse;
 
+    uint16_t auto_mouse_layer_timeout;
+    layer_state_t last_layer_state;
+
     // Buffer to indicate pressing keys.
     char pressing_keys[KEYBALL_OLED_MAX_PRESSING_KEYCODES + 1];
 } keyball_t;
@@ -270,3 +273,7 @@ uint8_t keyball_get_cpi(void);
 /// In addition, if you do not upload SROM, the maximum value will be limited
 /// to 34 (3500CPI).
 void keyball_set_cpi(uint8_t cpi);
+
+#ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
+void keyball_keep_auto_mouse_layer_if_needed(layer_state_t state);
+#endif

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
@@ -179,6 +179,7 @@ typedef struct {
 
     uint16_t auto_mouse_layer_timeout;
     layer_state_t last_layer_state;
+    uint16_t total_mouse_movement;
 
     // Buffer to indicate pressing keys.
     char pressing_keys[KEYBALL_OLED_MAX_PRESSING_KEYCODES + 1];
@@ -275,5 +276,5 @@ uint8_t keyball_get_cpi(void);
 void keyball_set_cpi(uint8_t cpi);
 
 #ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
-void keyball_keep_auto_mouse_layer_if_needed(layer_state_t state);
+void keyball_handle_auto_mouse_layer_change(layer_state_t state);
 #endif


### PR DESCRIPTION
Auto Mouse Layer の機能を使うと以下のような誤爆が起こりがち。

- タイムアウトを短くすると…
    - クリックする前にマウスレイヤーが解除され、クリックのつもりが文字入力になってしまう
- タイムアウトを長くすると…
    - マウスレイヤーが解除されておらず、文字入力のつもりがクリックになってしまう

マウスカーソルを動かすのはほとんどの場合、何かをクリックしたいからであって、クリックするまでマウスレイヤー抜ける必要はないはず。
次の仕様によってこれらの誤爆を減らす。

- マウスレイヤーに入ったら、マウスキーを押すまでマウスレイヤーに留まり続ける
- マウスキーを押したら短時間でマウスレイヤーを解除する

```mermaid
stateDiagram

state "マウスレイヤーに留まる" as keep
state "マウスレイヤーから短時間で抜ける" as short
state "Layer 0" as L0

L0 --> keep: マウスカーソルが動いた
keep --> short: マウスキーが押下された
short --> keep: マウスカーソルが動いた
short --> L0: タイムアウト
```

詳細な仕様は以下の通り。

- デフォルトの Auto Mouse Layer のタイムアウトを長めの 30s (`AUTO_MOUSE_LAYER_KEEP_TIME`) にする
    - クリックする前にマウスレイヤーが解除され、キー入力を誤爆してしまうのを防止
- マウスキーをクリックすると 100ms ～ 1000ms の時間でマウスレイヤーを離脱
    - 通常の Auto Mouse Layer のタイムアウトと同じ方法で調整できる
- マウスキークリック後にトラックボールを動かすと、タイムアウト値を `AUTO_MOUSE_LAYER_KEEP_TIME` にリセットする

意図せずトラックボールを触ってしまいマウスレイヤーが有効になってしまうのを防ぐため、以下の仕様を追加する。

- `AML_ACTIVATE_THRESHOLD` の移動量を超えたときだけマウスレイヤーに入る